### PR TITLE
Apply 'formatter_class' also to subparsers

### DIFF
--- a/.github/workflows/Workflow.yml
+++ b/.github/workflows/Workflow.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/pyAttributes/ArgParseAttributes.py
+++ b/pyAttributes/ArgParseAttributes.py
@@ -283,9 +283,9 @@ class ArgParseMixin(AttributeHelperMixin):
 			if (len(attributes) == 1):
 				attribute : CommandAttribute = attributes[0]
 				kwArgs = attribute.KWArgs.copy()
-				if ("formatter_class" not in kwArgs):
+				if ("formatter_class" not in kwArgs and self.__formatter is not None):
 					kwArgs["formatter_class"] = self.__formatter
-				subParser = self.__subParser.add_parser(attribute.Command, **(kwArgs))
+				subParser = self.__subParser.add_parser(attribute.Command, **kwArgs)
 				subParser.set_defaults(func=attribute.Handler)
 
 				attributes2: List[ArgumentAttribute] = self.GetAttributes(method, filter=ArgumentAttribute)

--- a/pyAttributes/ArgParseAttributes.py
+++ b/pyAttributes/ArgParseAttributes.py
@@ -19,7 +19,7 @@
 #
 # License:
 # ============================================================================
-# Copyright 2017-2020 Patrick Lehmann - Bötzingen, Germany
+# Copyright 2017-2021 Patrick Lehmann - Bötzingen, Germany
 # Copyright 2007-2016 Patrick Lehmann - Dresden, Germany
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -238,6 +238,7 @@ class ArgParseMixin(AttributeHelperMixin):
 	"""
 	__mainParser: ArgumentParser =  None
 	__subParser =   None
+	__formatter =   None
 	__subParsers =  {}
 
 	def __init__(self, **kwargs):
@@ -246,6 +247,9 @@ class ArgParseMixin(AttributeHelperMixin):
 		are passed without modification to the :class:`ArgumentParser` constructor.
 		"""
 		super().__init__()
+
+		if ("formatter_class" in kwargs):
+			self.__formatter = kwargs["formatter_class"]
 
 		# create a commandline argument parser
 		self.__mainParser = ArgumentParser(**kwargs)
@@ -277,8 +281,11 @@ class ArgParseMixin(AttributeHelperMixin):
 		methods = self.GetMethods(filter=CommandAttribute)
 		for method, attributes in methods.items():
 			if (len(attributes) == 1):
-				attribute = attributes[0]
-				subParser = self.__subParser.add_parser(attribute.Command, **(attribute.KWArgs))
+				attribute : CommandAttribute = attributes[0]
+				kwArgs = attribute.KWArgs.copy()
+				if ("formatter_class" not in kwArgs):
+					kwArgs["formatter_class"] = self.__formatter
+				subParser = self.__subParser.add_parser(attribute.Command, **(kwArgs))
 				subParser.set_defaults(func=attribute.Handler)
 
 				attributes2: List[ArgumentAttribute] = self.GetAttributes(method, filter=ArgumentAttribute)
@@ -290,25 +297,25 @@ class ArgParseMixin(AttributeHelperMixin):
 				raise Exception("Defined more then one 'CommandAttribute' per handler method.")
 
 
-	def Run(self, enableAutoComplete=True):
+	def Run(self, enableAutoComplete=True) -> None:
 		if enableAutoComplete:
 			self._EnabledAutoComplete()
 
 		self._ParseArguments()
 
-	def _EnabledAutoComplete(self):
+	def _EnabledAutoComplete(self) -> None:
 		try:
 			from argcomplete  import autocomplete
 			autocomplete(self.__mainParser)
 		except ImportError:
 			pass
 
-	def _ParseArguments(self):
+	def _ParseArguments(self) -> None:
 		# parse command line options and process split arguments in callback functions
 		args = self.__mainParser.parse_args()
 		self._RouteToHandler(args)
 
-	def _RouteToHandler(self, args):
+	def _RouteToHandler(self, args) -> None:
 		# because func is a function (unbound to an object), it MUST be called with self as a first parameter
 		args.func(self, args)
 

--- a/pyAttributes/__init__.py
+++ b/pyAttributes/__init__.py
@@ -19,7 +19,7 @@
 #
 # License:
 # ============================================================================
-# Copyright 2017-2020 Patrick Lehmann - Bötzingen, Germany
+# Copyright 2017-2021 Patrick Lehmann - Bötzingen, Germany
 # Copyright 2007-2016 Patrick Lehmann - Dresden, Germany
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ rtd_url =     "https://" + projectName + ".readthedocs.io/en/latest/"
 
 setuptools.setup(
 	name=projectName,
-	version="2.0.1",
+	version="2.1.0",
 
 	author="Patrick Lehmann",
 	author_email="Paebbels@gmail.com",
@@ -82,6 +82,7 @@ setuptools.setup(
 		"Programming Language :: Python :: 3.6",
 		"Programming Language :: Python :: 3.7",
 		"Programming Language :: Python :: 3.8",
+		"Programming Language :: Python :: 3.9",
 		"Development Status :: 5 - Production/Stable",
 		"Intended Audience :: Developers",
 		"Topic :: Utilities"

--- a/tests/example/UserManager.py
+++ b/tests/example/UserManager.py
@@ -1,4 +1,6 @@
-from pyAttributes.ArgParseAttributes import ArgParseMixin, CommonSwitchArgumentAttribute, DefaultAttribute, CommandAttribute, ArgumentAttribute, SwitchArgumentAttribute
+from argparse import ArgumentDefaultsHelpFormatter
+
+from pyAttributes.ArgParseAttributes import ArgParseMixin, CommonSwitchArgumentAttribute, DefaultAttribute, CommandAttribute, CommonArgumentAttribute, ArgumentAttribute, SwitchArgumentAttribute
 
 
 class ProgramBase():
@@ -15,7 +17,6 @@ class ProgramBase():
 
 class Program(ProgramBase, ArgParseMixin):
 	def __init__(self):
-		import argparse
 		import textwrap
 
 		# call constructor of the main inheritance tree
@@ -28,7 +29,7 @@ class Program(ProgramBase, ArgParseMixin):
         This is the test program.
         '''),
 			epilog=textwrap.fill("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam."),
-			formatter_class=argparse.RawDescriptionHelpFormatter,
+			formatter_class=ArgumentDefaultsHelpFormatter,
 			add_help=False
 		)
 
@@ -70,7 +71,7 @@ class Program(ProgramBase, ArgParseMixin):
 	def HandleNewUser(self, args):
 		self.PrintHeadline()
 
-		print("HandleHelp:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  UserID={3!s}  Name={4!s}".format(args.quiet, args.verbose, args.debug, args.UserID, args.Name))
+		print("HandleNewUser:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  UserID={3!s}  Name={4!s}  Limit={5!s}".format(args.quiet, args.verbose, args.debug, args.UserID, args.Name, args.Limit))
 
 
 	@CommandAttribute("delete-user", help="Delete a user.")
@@ -78,7 +79,7 @@ class Program(ProgramBase, ArgParseMixin):
 	def HandleDeleteUser(self, args):
 		self.PrintHeadline()
 
-		print("HandleHelp:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  UserID={3!s}".format(args.quiet, args.verbose, args.debug, args.UserID))
+		print("HandleDeleteUser:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  UserID={3!s}".format(args.quiet, args.verbose, args.debug, args.UserID))
 
 
 	@CommandAttribute("list-user", help="List users.")
@@ -86,7 +87,7 @@ class Program(ProgramBase, ArgParseMixin):
 	def HandleListUser(self, args):
 		self.PrintHeadline()
 
-		print("HandleHelp:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  all={3!s}".format(args.quiet, args.verbose, args.debug, args.all))
+		print("HandleListUser:\n  quiet={0!s}\n  verbose={1!s}\n  debug={2!s}\n\n  all={3!s}".format(args.quiet, args.verbose, args.debug, args.all))
 
 
 if __name__ == "__main__":

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,3 @@
 
 # Coverage collection
 Coverage>=5.2.1
-
-# Coverage upload tools
-codacy-coverage>=1.3.11
-codecov>=2.1.9


### PR DESCRIPTION
This PR will grab the `formatter_class` from the main parser (if specified) and apply it to all subparsers (if not yet specified).

**Related to:**
* https://github.com/hdl/containers/issues/23

---------------
/cc @umarcor